### PR TITLE
Added defaultConfig parameter to the options

### DIFF
--- a/src/associations/associate.js
+++ b/src/associations/associate.js
@@ -4,9 +4,11 @@ import { capitalize } from 'lodash/string';
 import { getMethod } from '../utils';
 
 let prefix;
+let defaultConfig;
 
 export default (server, a, b, names, options) => {
   prefix = options.prefix;
+  defaultConfig = options.defaultConfig;
 
   server.route({
     method: 'GET',
@@ -31,6 +33,8 @@ export default (server, a, b, names, options) => {
       await fn(instanceb);
 
       reply([instancea, instanceb]);
-    }
+    },
+
+    config: defaultConfig
   })
 }

--- a/src/associations/one-to-many.js
+++ b/src/associations/one-to-many.js
@@ -4,9 +4,11 @@ import _ from 'lodash';
 import { parseInclude, parseWhere, getMethod } from '../utils';
 
 let prefix;
+let defaultConfig;
 
 export default (server, a, b, names, options) => {
   prefix = options.prefix;
+  defaultConfig = options.defaultConfig;
 
   get(server, a, b, names);
   list(server, a, b, names);
@@ -38,7 +40,9 @@ export const get = (server, a, b, names) => {
       }, include });
 
       reply(list);
-    }
+    },
+
+    config: defaultConfig
   })
 }
 
@@ -62,7 +66,9 @@ export const list = (server, a, b, names) => {
       const list = await method({ where, include });
 
       reply(list);
-    }
+    },
+
+    config: defaultConfig
   })
 }
 
@@ -94,14 +100,14 @@ export const scope = (server, a, b, names) => {
       reply(list);
     },
 
-    config: {
+    config: _.defaults({
       validate: {
         params: joi.object().keys({
           scope: joi.string().valid(...scopes),
           aid: joi.number().integer().required()
         })
       }
-    }
+    }, defaultConfig)
   })
 }
 
@@ -130,14 +136,14 @@ export const scopeScope = (server, a, b, names) => {
       reply(list);
     },
 
-    config: {
+    config: _.defaults({
       validate: {
         params: joi.object().keys({
           scopea: joi.string().valid(...scopes.a),
           scopeb: joi.string().valid(...scopes.b)
         })
       }
-    }
+    }, defaultConfig)
   })
 }
 
@@ -199,14 +205,14 @@ export const destroyScope = (server, a, b, names) => {
       reply(list);
     },
 
-    config: {
+    config: _.defaults({
       validate: {
         params: joi.object().keys({
           scope: joi.string().valid(...scopes),
           aid: joi.number().integer().required()
         })
       }
-    }
+    }, defaultConfig)
   });
 }
 
@@ -232,6 +238,8 @@ export const update = (server, a, b, names) => {
       await* list.map(instance => instance.update(request.payload));
 
       reply(list);
-    }
+    },
+
+    config: defaultConfig
   })
 }

--- a/src/associations/one-to-many.js
+++ b/src/associations/one-to-many.js
@@ -100,7 +100,7 @@ export const scope = (server, a, b, names) => {
       reply(list);
     },
 
-    config: _.defaults({
+    config: _.defaultsDeep({
       validate: {
         params: joi.object().keys({
           scope: joi.string().valid(...scopes),
@@ -136,7 +136,7 @@ export const scopeScope = (server, a, b, names) => {
       reply(list);
     },
 
-    config: _.defaults({
+    config: _.defaultsDeep({
       validate: {
         params: joi.object().keys({
           scopea: joi.string().valid(...scopes.a),
@@ -205,7 +205,7 @@ export const destroyScope = (server, a, b, names) => {
       reply(list);
     },
 
-    config: _.defaults({
+    config: _.defaultsDeep({
       validate: {
         params: joi.object().keys({
           scope: joi.string().valid(...scopes),

--- a/src/associations/one-to-one.js
+++ b/src/associations/one-to-one.js
@@ -4,9 +4,11 @@ import _ from 'lodash';
 import { parseInclude, parseWhere, getMethod } from '../utils';
 
 let prefix;
+let defaultConfig;
 
 export default (server, a, b, names, options) => {
   prefix = options.prefix;
+  defaultConfig = options.defaultConfig;
 
   get(server, a, b, names);
   create(server, a, b, names);
@@ -38,7 +40,9 @@ export const get = (server, a, b, names) => {
       } else {
         reply(list);
       }
-    }
+    },
+
+    config: defaultConfig
   })
 }
 
@@ -59,7 +63,9 @@ export const create = (server, a, b, names) => {
       const instance = await method(request.payload);
 
       reply(instance);
-    }
+    },
+
+    config: defaultConfig
   })
 }
 
@@ -84,7 +90,9 @@ export const destroy = (server, a, b, names) => {
       await instance.destroy();
 
       reply(instance);
-    }
+    },
+
+    config: defaultConfig
   })
 }
 
@@ -110,6 +118,8 @@ export const update = (server, a, b, names) => {
       await instance.update(request.payload);
 
       reply(instance);
-    }
+    },
+
+    config: defaultConfig
   })
 }

--- a/src/crud.js
+++ b/src/crud.js
@@ -4,9 +4,11 @@ import _ from 'lodash';
 import { parseInclude, parseWhere } from './utils';
 
 let prefix;
+let defaultConfig;
 
 export default (server, model, options) => {
   prefix = options.prefix;
+  defaultConfig = options.defaultConfig;
 
   list(server, model);
   get(server, model);
@@ -33,7 +35,9 @@ export const list = (server, model) => {
       });
 
       reply(list);
-    }
+    },
+
+    config: defaultConfig
   });
 }
 
@@ -52,13 +56,13 @@ export const get = (server, model) => {
 
       reply(instance);
     },
-    config: {
+    config: _.defaults({
       validate: {
         params: joi.object().keys({
           id: joi.number().integer()
         })
       }
-    }
+    }, defaultConfig)
   })
 }
 
@@ -78,13 +82,13 @@ export const scope = (server, model) => {
 
       reply(list);
     },
-    config: {
+    config: _.defaults({
       validate: {
         params: joi.object().keys({
           scope: joi.string().valid(...scopes)
         })
       }
-    }
+    }, defaultConfig)
   });
 }
 
@@ -98,7 +102,9 @@ export const create = (server, model) => {
       const instance = await model.create(request.payload);
 
       reply(instance);
-    }
+    },
+
+    config: defaultConfig
   })
 }
 
@@ -118,7 +124,9 @@ export const destroy = (server, model) => {
       await* list.map(instance => instance.destroy());
 
       reply(list.length === 1 ? list[0] : list);
-    }
+    },
+
+    config: defaultConfig
   })
 }
 
@@ -137,7 +145,9 @@ export const destroyAll = (server, model) => {
       await* list.map(instance => instance.destroy());
 
       reply(list.length === 1 ? list[0] : list);
-    }
+    },
+
+    config: defaultConfig
   })
 }
 
@@ -159,13 +169,13 @@ export const destroyScope = (server, model) => {
 
       reply(list);
     },
-    config: {
+    config: _.defaults({
       validate: {
         params: joi.object().keys({
           scope: joi.string().valid(...scopes)
         })
       }
-    }
+    }, defaultConfig)
   });
 }
 
@@ -185,7 +195,9 @@ export const update = (server, model) => {
       await instance.update(request.payload);
 
       reply(instance);
-    }
+    },
+
+    config: defaultConfig
   })
 }
 

--- a/src/crud.js
+++ b/src/crud.js
@@ -56,7 +56,7 @@ export const get = (server, model) => {
 
       reply(instance);
     },
-    config: _.defaults({
+    config: _.defaultsDeep({
       validate: {
         params: joi.object().keys({
           id: joi.number().integer()
@@ -82,7 +82,7 @@ export const scope = (server, model) => {
 
       reply(list);
     },
-    config: _.defaults({
+    config: _.defaultsDeep({
       validate: {
         params: joi.object().keys({
           scope: joi.string().valid(...scopes)
@@ -169,7 +169,7 @@ export const destroyScope = (server, model) => {
 
       reply(list);
     },
-    config: _.defaults({
+    config: _.defaultsDeep({
       validate: {
         params: joi.object().keys({
           scope: joi.string().valid(...scopes)


### PR DESCRIPTION
Let the user add a defaultConfig object when initializing the plugin. This object is then used to populate the config parameter of all the routes generated.

This is useful for example to tag all the routes generated by this plugin.
