### PR TITLE
Add: Better errors

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -1,3 +1,5 @@
+import { wrap } from 'boom';
+
 export default (target, key, descriptor) => {
   const fn = descriptor.value;
 
@@ -5,8 +7,22 @@ export default (target, key, descriptor) => {
     try {
       await fn(request, reply);
     } catch (e) {
-      console.error(e);
-      reply(e);
+      const { code, detail } = e.original;
+
+      // pg error codes https://www.postgresql.org/docs/9.5/static/errcodes-appendix.html
+      if (code && (code.startsWith('22') || code.startsWith('23'))) {
+        const error = wrap(e, 406);
+
+        // detail tends to be more specific information. So, if we have it, use.
+        if (detail) {
+          error.message += `: ${detail}`;
+          error.reformat();
+        }
+
+        reply(error);
+      } else {
+        reply(wrap(e));
+      }
     }
   };
 


### PR DESCRIPTION
Now looks at the error that comes back from sequelize and uses boom to
format the error in a more friendly way. This should yield useful error
messages instead of generic 500s.
