### PR TITLE
Fix a bug in error parsing

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -13,7 +13,15 @@ export default (target, key, descriptor) => {
 
         // pg error codes https://www.postgresql.org/docs/9.5/static/errcodes-appendix.html
         if (code && (code.startsWith('22') || code.startsWith('23'))) {
-          const error = Boom.wrap(e, 406);
+          error = Boom.wrap(e, 406);
+        } else if (code && (code.startsWith('42'))) {
+          error = Boom.wrap(e, 422);
+        // TODO: we could get better at parse postgres error codes
+        } else {
+          // use a 502 error code since the issue is upstream with postgres, not
+          // this server
+          error = Boom.wrap(e, 502);
+        }
 
         // detail tends to be more specific information. So, if we have it, use.
         if (detail) {

--- a/src/error.js
+++ b/src/error.js
@@ -14,14 +14,15 @@ export default (target, key, descriptor) => {
         if (code && (code.startsWith('22') || code.startsWith('23'))) {
           const error = Boom.wrap(e, 406);
 
-          // detail tends to be more specific information. So, if we have it, use.
-          if (detail) {
-            error.message += `: ${detail}`;
-            error.reformat();
-          }
-
-          reply(error);
+        // detail tends to be more specific information. So, if we have it, use.
+        if (detail) {
+          error.message += `: ${detail}`;
+          error.reformat();
         }
+
+        }
+
+        reply(error);
       } else if (!e.isBoom) {
         const { message } = e;
         let err;

--- a/src/error.js
+++ b/src/error.js
@@ -8,7 +8,8 @@ export default (target, key, descriptor) => {
       await fn(request, reply);
     } catch (e) {
       if (e.original) {
-        const { code, detail } = e.original;
+        const { code, detail, hint } = e.original;
+        let error;
 
         // pg error codes https://www.postgresql.org/docs/9.5/static/errcodes-appendix.html
         if (code && (code.startsWith('22') || code.startsWith('23'))) {
@@ -20,6 +21,10 @@ export default (target, key, descriptor) => {
           error.reformat();
         }
 
+        // hint might provide useful information about how to fix the problem
+        if (hint) {
+          error.message += ` Hint: ${hint}`;
+          error.reformat();
         }
 
         reply(error);


### PR DESCRIPTION
Fixes a case where the server could hang b/c we'd never call `reply`. Also adds some better parsing around PG errors.

This is a patch release.
