### PR TITLE
Fix(crud) include param lookup now works w/plurals

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Getting related models is easy, just use a query parameter `include`.
 
 ```js
 // returns all teams with their related City model
-// GET /teams?include=City
+// GET /teams?include=city
 
 // results in a Sequelize query:
 Team.findAll({include: City})
@@ -118,10 +118,19 @@ Team.findAll({include: City})
 If you want to get multiple related models, just pass multiple `include` parameters.
 ```js
 // returns all teams with their related City and Uniform models
-// GET /teams?include=City&include=Uniform
+// GET /teams?include[]=city&include[]=uniform
 
 // results in a Sequelize query:
 Team.findAll({include: [City, Uniform]})
+```
+
+For models that have a many-to-many relationship, you can also pass the plural version of the association.
+```js
+// returns all teams with their related City and Uniform models
+// GET /teams?include=players
+
+// results in a Sequelize query:
+Team.findAll({include: [Player]})
 ```
 
 ## `limit` and `offset` queries

--- a/src/crud.js
+++ b/src/crud.js
@@ -62,8 +62,9 @@ export default (server, model, { prefix, defaultConfig: config, models: permissi
     return params;
   }, {});
 
+  const validAssociations = joi.string().valid(...modelAssociations);
   const associationValidation = {
-    include: joi.array().items(joi.string().valid(...modelAssociations)),
+    include: [joi.array().items(validAssociations), validAssociations],
   };
 
   const scopes = Object.keys(model.options.scopes);

--- a/src/crud.js
+++ b/src/crud.js
@@ -55,7 +55,15 @@ models: {
 export default (server, model, { prefix, defaultConfig: config, models: permissions }) => {
   const modelName = model._singular;
   const modelAttributes = Object.keys(model.attributes);
-  const modelAssociations = Object.keys(model.associations);
+  const associatedModelNames = Object.keys(model.associations);
+  const modelAssociations = [
+    ...associatedModelNames,
+    ..._.flatMap(associatedModelNames, (associationName) => {
+      const { target } = model.associations[associationName];
+      const { _singular, _plural, _Singular, _Plural } = target;
+      return [_singular, _plural, _Singular, _Plural];
+    }),
+  ];
 
   const attributeValidation = modelAttributes.reduce((params, attribute) => {
     params[attribute] = joi.any();

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,6 @@ const register = (server, options = {}, next) => {
     // Join tables
     if (model.options.name.singular !== model.name) continue;
 
-    crud(server, model, options);
 
     for (const key of Object.keys(model.associations)) {
       const association = model.associations[key];
@@ -91,6 +90,13 @@ const register = (server, options = {}, next) => {
       }
     }
   }
+
+  // build the methods for each model now that we've defined all the
+  // associations
+  Object.keys(models).forEach((modelName) => {
+    const model = models[modelName];
+    crud(server, model, options);
+  });
 
   next();
 };

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,8 @@ const register = (server, options = {}, next) => {
     const { plural, singular } = model.options.name;
     model._plural = plural.toLowerCase();
     model._singular = singular.toLowerCase();
+    model._Plural = plural;
+    model._Singular = singular;
 
     // Join tables
     if (model.options.name.singular !== model.name) continue;

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,13 @@ export const parseInclude = request => {
   const { models } = noGetDb ? request : request.getDb();
 
   return include.map(a => {
+    const singluarOrPluralMatch = Object.keys(models).find((modelName) => {
+      const { _singular, _plural } = models[modelName];
+      return _singular === a || _plural === a;
+    });
+
+    if (singluarOrPluralMatch) return models[singluarOrPluralMatch];
+
     if (typeof a === 'string') return models[a];
 
     if (a && typeof a.model === 'string' && a.model.length) {


### PR DESCRIPTION
Previously, {one,many}-to-many relationships with models would result in
`associationNames` that were plural. e.g. `Team` might have many players
and one location. The validation was expecting to see the plural
`Players` and the singular `Location` but Sequelize is expecting the
singular `Player` (`Location` worked fine). This meant that include lookups
would silently fail. This fixes the problem in a backward- compatible way.

It continues to allow `include=Location` (capitalized) for backward-
compatibility. And now allows and actually does the lookup for
`include=players`, `include=player`, `include=Player`, `include=Players`
lookup relationships.

There are also a few small changes that enable the above.

I'm working on a separate PR that adds integration tests so that we can ensure this kind of thing doesn't happen again.
